### PR TITLE
Build: Update Python and libraries.

### DIFF
--- a/.github/workflows/qax-build.yaml
+++ b/.github/workflows/qax-build.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: ["windows-latest", "ubuntu-latest"]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     env:
       # mostly used as helpers for retrieving as env vars within inno setup

--- a/.github/workflows/regular-build.yaml
+++ b/.github/workflows/regular-build.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: ["windows-latest", "ubuntu-latest"]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     env:
       # mostly used as helpers for retrieving as env vars within inno setup

--- a/conda-environment.yaml
+++ b/conda-environment.yaml
@@ -5,23 +5,24 @@ channels:
 dependencies:
   - git
   - certifi
-  - GDAL==3.6.2
-  - tiledb==2.13.2
-  - sphinx
+  - GDAL==3.8.3
+  - tiledb==2.19.1
+  - sphinx==7.2.6
   - qt-main==5.15.8
   - qt-webengine==5.15.8
-  - qtawesome
-  - cartopy
-  - pyproj=3.4.1
+  - qtawesome==1.3.0
+  - cartopy==0.22.0
+  - proj==9.3.1
+  - pyproj==3.6.1
   - pyside2==5.15.8
   - pywin32
-  - numpy==1.23.5
-  - scipy=1.10.0
-  - numba==0.56.4
-  - numexpr==2.8.3
-  - pdal=2.5.0
-  - python-pdal==3.2.2
-  - rasterio==1.3.6
-  - pip>=20.1
+  - numpy==1.26.4
+  - scipy==1.12.0
+  - numba==0.59.0
+  - numexpr==2.9.0
+  - conda-forge::pdal==2.6.3
+  - conda-forge::python-pdal==3.3.0
+  - rasterio>=1.3.9
+  - pip==24.0
   - pip:
     - -r requirements.txt

--- a/docs/user_manual_installation.rst
+++ b/docs/user_manual_installation.rst
@@ -41,7 +41,7 @@ Create conda environment for QAX
 Start by installing `miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ (on Windows) and and then establishing an environment to install necessary dependencies (eg NumPy, GDAL, hyo2.abc, hyo2.mate) via the `conda-environment.yaml` file, followed by  QAX itself.
 The following command sequence is suggested: ::
 
-    conda create -y -n qax python=3.10
+    conda create -y -n qax python=3.11
     conda env update --file conda-environment.yaml
     conda activate qax
 


### PR DESCRIPTION
Build: Update base Python from 3.10 to 3.11; Update dependencies and set with explicit version tags.

Python 3.10 (3.5 years) is quite old, dependencies such as numpy and scipy have had security updates, and many other dependencies have had updates and improvements.

Aiming to pin most of the non-ausseabed related dependencies.