### PR TITLE
Resovle missing map

### DIFF
--- a/install/cli.spec
+++ b/install/cli.spec
@@ -45,7 +45,7 @@ datas.append((qml_libs ,"."))
 datas.append((pyside2_libs, "PySide2"))
 datas.append((styles_libs, "styles"))
 datas.append((platformthemes_libs, "plugins\\platformthemes"))
-datas.append((geoservices_libs, "geoservices"))
+datas.append((geoservices_libs, "PySide2\\plugins\\geoservices"))
 datas.append((r'..\docs\_build\html', "docs\_build\html"))
 datas.append((ggoutlier_pngs ,"."))
 


### PR DESCRIPTION
This PR resolves the missing map tab as described in #32.

PySide2 is natively looking for plugins based on:

```python
from PySide2.QtCore import QLibraryInfo
print(QLibraryInfo.location(QLibraryInfo.PluginsPath)
```

Which for conda is something like (on Windows):

```shell
miniconda3/envs/<env>/Library/plugins
```

But for QAX, pyinstaller has to change it so that QAX can be self-contained.

